### PR TITLE
NOTS: Fix Kubernetes client auth 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.egg-info/
 *.pyc
 *.swp
+.claude/

--- a/src/deploy_notifier/kube_monitor.py
+++ b/src/deploy_notifier/kube_monitor.py
@@ -51,17 +51,28 @@ class Kubernetes(object):
             artifactory_url: typing.Optional[str] = None,
             artifactory_login: typing.Optional[str] = None):
         if config_file is None:
-            kubernetes.config.load_incluster_config()
+            # Remove proxy env vars before initialising the kubernetes client so
+            # in-cluster API calls are never routed through the corporate proxy.
+            # Restored afterwards so Artifactory/Slack calls still use the proxy.
+            _proxy_vars = {k: os.environ.pop(k) for k in
+                ('http_proxy', 'HTTP_PROXY', 'https_proxy', 'HTTPS_PROXY',
+                 'all_proxy', 'ALL_PROXY')
+                if k in os.environ}
+            try:
+                cfg = Configuration()
+                kubernetes.config.load_incluster_config(client_configuration=cfg)
+                api_client = kubernetes.client.ApiClient(configuration=cfg)
+            finally:
+                os.environ.update(_proxy_vars)
+            self._token_file = '/var/run/secrets/kubernetes.io/serviceaccount/token'
         else:
             kubernetes.config.load_kube_config(config_file=config_file)
+            api_client = kubernetes.client.ApiClient(
+                configuration=Configuration.get_default_copy())
+            self._token_file = None
 
-        # IMPORTANT: disable proxy for Kubernetes client, so internal kubernetes calls are not sent through proxy
-        cfg = Configuration.get_default_copy()
-        cfg.proxy = None
-        cfg.proxy_headers = None
-        Configuration.set_default(cfg)
-
-        self.apps = kubernetes.client.AppsV1Api()
+        self._api_client = api_client
+        self.apps = kubernetes.client.AppsV1Api(api_client=api_client)
         self.slack_info = slack_info
         # slack only supports http proxies
         if os.getenv("http_proxy") is not None:
@@ -80,10 +91,16 @@ class Kubernetes(object):
             else:
                 self.artifactory_login = ArtifactoryLogin(parts[0], parts[1])
 
+    def _refresh_token(self):
+        if self._token_file:
+            with open(self._token_file) as f:
+                self._api_client.default_headers['Authorization'] = 'Bearer ' + f.read().strip()
+
     def watch_for_changes(self, namespace: str):
         self.watch_for_deployment_changes(namespace)
 
     def watch_for_deployment_changes(self, namespace: str, wait: int = 5):
+        self._refresh_token()
         logger.info("Watching namespace {}".format(namespace))
         events = self.get_events_file_from_artifactory(namespace)
         watch = kubernetes.watch.Watch()
@@ -123,7 +140,7 @@ class Kubernetes(object):
                     logger.info(msg)
                     notify_slack(self.slack_client, self.slack_info.channel, msg)
         except ApiException as e:
-            if e.status == 410: # Resource too old
+            if e.status in (410, 401):
                 logger.info(f"An error happened: {e} - Restarting watch.")
                 return self.watch_for_changes(namespace)
             else:


### PR DESCRIPTION
Efter en dags kamp med claude og k8s, er dette hvad jeg nåede frem til.

### Fix Kubernetes client auth broken by dependency update

After an unplanned update to an unpinned dependency (likely the kubernetes Python package or one of its transitive dependencies), the client stopped sending the Authorization header on API requests, causing all requests to arrive as system:anonymous.

The previous proxy fix (`Configuration.get_default_copy() + set_default()`) relied on global configuration state that the updated client no longer honours. Additionally, the client started picking up http_proxy env vars internally and routing in-cluster API calls through the corporate proxy, which strips the auth header.

Changes:
- Proxy env vars are temporarily removed from the environment during kubernetes client initialisation (restored immediately after, so Artifactory/Slack
calls are unaffected)
- Configuration is loaded directly into an explicit `Configuration()` object and passed as `api_client` to `AppsV1Api`, bypassing global config state entirely
- The Authorization header is set directly on the `ApiClient` and re-read from the token file at the start of each watch cycle, so projected SA token rotations (~1h) are handled without a pod restart
- 401 responses are now handled the same as 410 (restart the watch), covering token expiry mid-stream

Note: `setup.py` has no version pins on kubernetes or its dependencies — pinning versions would prevent this class of silent breakage in future.
  