### PR TITLE
try fixing crashbackloop cache issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ happens.
 
 ## Config
 The deployment monitor needs a kubernetes config in order to access
-kubernetes. This can be a local file such as .kube/config. Or it can be
+kubernetes. This can be a local file such as `.kube/config`. Or it can be
 supplied by the kubernetes cluster itself if the deployment monitor is
 deployed in the cluster and a service account, using the `serviceAccountName`
 attribute, is configured.
@@ -14,4 +14,53 @@ attribute, is configured.
 ## Cache
 The deployment monitor keeps a cache of events it has seen to avoid
 reporting the same event multiple times in case of restarts. This cache
-is kept in a pickle file uploaded to artifactory.
+is stored as a JSON file in Artifactory.
+
+### File location
+
+The cache file is uploaded to and retrieved from Artifactory at:
+
+```
+<ARTIFACTORY_URL>/deployment-events-v<VERSION>-<OWN_NAMESPACE>-<namespace>.json
+```
+
+- `ARTIFACTORY_URL` — the Artifactory base URL configured for the service
+- `VERSION` — the cache schema version (currently `2`); bumped whenever the format changes to prevent pods from reading a stale or incompatible cache
+- `OWN_NAMESPACE` — the namespace the deploy-notifier itself runs in (from the `OWN_NAMESPACE` environment variable, defaulting to `default-namespace`)
+- `namespace` — the kubernetes namespace being watched
+
+Example filename for a notifier running in `platform` watching the `ai-prod` namespace:
+
+```
+deployment-events-v2-platform-ai-prod.json
+```
+
+### JSON format
+
+```json
+{
+  "events": {
+    "<deployment-name>": {
+      "type": "<ADDED|MODIFIED|DELETED>",
+      "object": {
+        "spec": { ... },
+        "metadata": null,
+        "status": null
+      }
+    }
+  }
+}
+```
+
+Each key under `events` is the name of a Kubernetes Deployment. The `type`
+field is the watch event type (`ADDED`, `MODIFIED`, or `DELETED`). The
+`object` field is a snapshot of the deployment's spec as returned by the
+Kubernetes API (`to_dict()`), with `metadata` and `status` set to `null` —
+these fields are excluded because they change continuously as part of
+Kubernetes reconciliation and would otherwise cause every reconciliation
+loop to be reported as a new deployment.
+
+The cache is read on startup and written after every event that triggers a
+Slack notification. If the file is missing or cannot be parsed, the notifier
+starts with an empty cache and behaves as if it has never seen any
+deployments before.

--- a/src/deploy_notifier/kube_monitor.py
+++ b/src/deploy_notifier/kube_monitor.py
@@ -5,10 +5,9 @@
 import argparse
 import collections
 import concurrent.futures
-import io
+import json
 import logging
 import os
-import pickle
 import sys
 import typing
 
@@ -44,6 +43,33 @@ Event = collections.namedtuple("Event", ["type", "object"])
 ArtifactoryLogin = collections.namedtuple("ArtifactoryLogin", ["user", "password"])
 
 OWN_NAMESPACE = os.getenv("OWN_NAMESPACE", "default-namespace")
+EVENTS_CACHE_VERSION = 2
+
+def get_events_filename(namespace: str) -> str:
+    return f"deployment-events-v{EVENTS_CACHE_VERSION}-{OWN_NAMESPACE}-{namespace}.json"
+
+def snapshot_deployment(kube_object) -> dict:
+    snapshot = kube_object.to_dict()
+    # Ignore fields that change as part of Kubernetes reconciliation and watch progress.
+    snapshot["metadata"] = None
+    snapshot["status"] = None
+    return snapshot
+
+def serialize_events(events: dict) -> str:
+    payload = {"events": {}}
+    for name, event in events.items():
+        payload["events"][name] = {"type": event.type, "object": event.object}
+    return json.dumps(payload, sort_keys=True)
+
+def deserialize_events(payload: str) -> dict:
+    data = json.loads(payload)
+    events = {}
+    for name, event in data.get("events", {}).items():
+        if "type" not in event or "object" not in event:
+            logger.warning("Skipping malformed cached event for %s", name)
+            continue
+        events[name] = Event(event["type"], event["object"])
+    return events
 
 class Kubernetes(object):
     def __init__(self, slack_info: SlackInfo,
@@ -100,19 +126,15 @@ class Kubernetes(object):
                     logger.info(f"Found kube object with name {name} and {kube_object.spec.replicas} replicas")
                     if "app.dbc.dk/team" in kube_object.spec.template.metadata.labels:
                         team = kube_object.spec.template.metadata.labels["app.dbc.dk/team"]
-                    # the status object contains information on different
-                    # update transitions and number of ready replicas, etc.,
-                    # so it isn't used when comparing different deployment versions
-                    kube_object.status = None
-                    kube_object.metadata = None
+                    deployment_snapshot = snapshot_deployment(kube_object)
                     # This condition checks how long it has been since a change
                     # was observed for a particular deployment. This is to avoid
                     # repporting all the individual stages a dployment goes
                     # through when it's modified by a user.
-                    if name in events and (events[name].type == event["type"] and events[name].object == kube_object):
+                    if name in events and (events[name].type == event["type"] and events[name].object == deployment_snapshot):
                         logger.info(f"Skipping {name} with type {events[name].type}")
                         continue
-                    events[name] = Event(event["type"], kube_object)
+                    events[name] = Event(event["type"], deployment_snapshot)
                     if self.artifactory_login is not None:
                         self.upload_events_to_artifactory(namespace, events)
                     action = "deployed to" if event["type"] != "DELETED" else "deleted from"
@@ -132,22 +154,25 @@ class Kubernetes(object):
     def get_events_file_from_artifactory(self, namespace: str) -> dict:
         if self.artifactory_login is not None:
             logger.info("getting events from artifactory")
-            filename = f"deployment-events-{OWN_NAMESPACE}-{namespace}.pickle"
+            filename = get_events_filename(namespace)
             url = f"{self.artifactory_url}/{filename}"
             response = requests.get(url, auth=(self.artifactory_login.user,
                 self.artifactory_login.password))
             if response.status_code == 200:
-                return pickle.load(io.BytesIO(response.content))
+                try:
+                    return deserialize_events(response.text)
+                except (TypeError, ValueError) as error:
+                    logger.warning("Ignoring invalid cached deployment events for %s: %s",
+                        namespace, error)
         return {}
 
     def upload_events_to_artifactory(self, namespace: str, events: dict) -> None:
-        filename = f"deployment-events-{OWN_NAMESPACE}-{namespace}.pickle"
+        filename = get_events_filename(namespace)
         url = f"{self.artifactory_url}/{filename}"
-        fp = io.BytesIO()
-        pickle.dump(events, fp)
-        fp.seek(0)
+        payload = serialize_events(events)
         response = requests.put(url, auth=(self.artifactory_login.user,
-            self.artifactory_login.password), data=fp)
+            self.artifactory_login.password), data=payload,
+            headers={"Content-Type": "application/json"})
         if response.status_code != 201:
             logger.error("Error uploading events to artifactory: {} - {}",
                 response.status_code, response.reason)


### PR DESCRIPTION
Vores deploy-notifier blive ved med at genstarte - codex mente det var et cache issue og har lavet følgende forslag til ændring. 
Jeg indrømmer gerne det her er ren vibe-coding, men her er samtalen med codex: 


```
my deploy-notifier runs in kubernetes and the deploy setup is found in a different repo: /home/kwc/gitlab/gitops-secrets/namespace/ai-
  prod/deploy-notifier-1-0. Right my pod in kubernetes often runs into CrashLoopBackOff with this logs: {"timestamp": "2026-06-
  03T06:08:10.674172+00:00", "message": "Watching namespace ai-prod", "host": "deploy-notifier-1-0-dd7fb997d-n5466", "path": "/home/
  python/.local/lib/python3.13/site-packages/deploy_notifier/kube_monitor.py", "level": "INFO", "logger": "root", "stack_info": null,
  "taskName": null}
  {"timestamp": "2026-06-03T06:08:10.674515+00:00", "message": "getting events from artifactory", "host": "deploy-notifier-1-0-
  dd7fb997d-n5466", "path": "/home/python/.local/lib/python3.13/site-packages/deploy_notifier/kube_monitor.py", "level": "INFO",
  "logger": "root", "stack_info": null, "taskName": null}
  {"timestamp": "2026-06-03T06:08:28.362578+00:00", "message": "Found kube object with name prosper-1-0 and 15 replicas", "host":
  "deploy-notifier-1-0-dd7fb997d-n5466", "path": "/home/python/.local/lib/python3.13/site-packages/deploy_notifier/kube_monitor.py",
  "level": "INFO", "logger": "root", "stack_info": null, "taskName": null}
  {"timestamp": "2026-06-03T06:08:28.363523+00:00", "message": "An error happened: 'V1PodSpec' object has no attribute
  '_scheduling_group'", "host": "deploy-notifier-1-0-dd7fb997d-n5466", "path": "/home/python/.local/lib/python3.13/site-packages/
  deploy_notifier/kube_monitor.py", "level": "ERROR", "logger": "root", "stack_info": null, "taskName": null}
   or this log: {"timestamp": "2026-06-03T08:17:45.928120+00:00", "message": "Watching namespace ai-prod", "host": "deploy-notifier-1-0-
  dd7fb997d-x859c", "path": "/home/python/.local/lib/python3.13/site-packages/deploy_notifier/kube_monitor.py", "level": "INFO",
  "logger": "root", "stack_info": null, "taskName": null}
  {"timestamp": "2026-06-03T08:17:45.928485+00:00", "message": "getting events from artifactory", "host": "deploy-notifier-1-0-
  dd7fb997d-x859c", "path": "/home/python/.local/lib/python3.13/site-packages/deploy_notifier/kube_monitor.py", "level": "INFO",
  "logger": "root", "stack_info": null, "taskName": null}
  {"timestamp": "2026-06-03T08:21:36.634435+00:00", "message": "Found kube object with name authority-finder-1-0 and 2 replicas",
  "host": "deploy-notifier-1-0-dd7fb997d-x859c", "path": "/home/python/.local/lib/python3.13/site-packages/deploy_notifier/
  kube_monitor.py", "level": "INFO", "logger": "root", "stack_info": null, "taskName": null}
  {"timestamp": "2026-06-03T08:21:36.634936+00:00", "message": "An error happened: Can't get local object
  'InClusterConfigLoader._set_config.<locals>._refresh_api_key'", "host": "deploy-notifier-1-0-dd7fb997d-x859c", "path": "/home/
  python/.local/lib/python3.13/site-packages/deploy_notifier/kube_monitor.py", "level": "ERROR", "logger": "root", "stack_info": null,
  "taskName": null}
  (K8S):~/ai-prod/deploy$ p
  . Do you an idea of what could be wrong.


 Yes. The CrashLoop is very likely caused by the event cache logic in src/deploy_notifier/kube_monitor.py:154, not by Kubernetes itself.

  - The code reads and writes deployment events to Artifactory using pickle on raw Kubernetes client objects.
  - The '_scheduling_group' error fits an old cached object being unpickled after a Kubernetes Python client change. The later equality
    check at src/deploy_notifier/kube_monitor.py:134 then touches a field that the old object does not have.

  - The Can't get local object ... _refresh_api_key error fits the current in-cluster client object graph not being picklable anymore
    when pickle.dump(...) runs at src/deploy_notifier/kube_monitor.py:169.

  - When that worker thread throws, main() logs the exception and exits with code 1 at src/deploy_notifier/kube_monitor.py:183, which
    becomes CrashLoopBackOff.

  I changed the app to stop storing raw Kubernetes objects and instead persist a versioned JSON snapshot of the deployment spec in src/
  deploy_notifier/kube_monitor.py:46. That avoids both the client-version mismatch and the non-picklable callback issue. Syntax check
  passed with python3 -m py_compile.


```